### PR TITLE
Fixed an issue in req.filter function

### DIFF
--- a/lib/restify_validator.js
+++ b/lib/restify_validator.js
@@ -129,7 +129,27 @@ var restifyValidator = function(req, res, next) {
       // Replace the param with the filtered version
       self.updateParam(param, str);
     };
-    return filter.sanitize(this.params+"."+param);
+    
+    var value;
+    
+    if (!Array.isArray(param)) {
+      param = typeof param === 'number' ?
+              [param] :
+              param.split('.').filter(function(e){
+                return e !== '';
+              });
+    }
+
+    // Extract value from params
+    param.map(function(item) {
+        if (value === undefined) {
+          value = req.params[item];
+        } else {
+          value = value[item];
+        }
+    });
+
+    return filter.sanitize(value);
   };
 
   // Create some aliases - might help with code readability


### PR DESCRIPTION
Hi Chris,

First of all thanks for the restify-validator module. It saved me a lot of time.
I have fixed an issue in req.filter function. When I pass param with dot notation it was not sanitizing. For example if there is a param like this

```
req.params.address.city
```

then I couldn't sanitize the city value like this

```
req.sanitize('address.city').trim();
```

I made a small change in the code to solve this problem. Please take time to merge this into the project.

Cheers,
Khaja Naquiuddin.
